### PR TITLE
Align accent dark color

### DIFF
--- a/themes/sanitarium/assets/css/main.css
+++ b/themes/sanitarium/assets/css/main.css
@@ -21,7 +21,7 @@
     --border-color-standard-rgb: 136, 136, 136; /* Match the hex #888888 */
 
     /* Accent colors for light/dark modes - using system color keywords */
-    --accent-color-dark: LinkText;  /* Browser's default link color in dark mode */
+    --accent-color-dark: #9e9eff;  /* Browser's default link color in dark mode for Firefox and Safari */
     --accent-color-light: #b30000; /* Red for light mode */
 
     /* Quote styling variables */

--- a/themes/sanitarium/layouts/_default/page.banner.html
+++ b/themes/sanitarium/layouts/_default/page.banner.html
@@ -15,7 +15,7 @@
         --system-serif: Charter, 'Bitstream Charter', 'Sitka Text', Cambria, serif;
 
         /* Dark mode color variables */
-        --accent-color-dark: LinkText; /* Browser default link color in dark mode */
+        --accent-color-dark: #9E9EFF; /* Browser default link color in dark mode on Firefox and Safari */
         --border-color-standard: #888888;
 
         /* Spacing variables */


### PR DESCRIPTION
Turns out it's different in Chrome